### PR TITLE
feat: allow specifying a path format for subtitles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ cookies/
 subtitles_all.txt.gz.2*T*.*Z*
 new-subs/
 opensubtitles-scraper-new-subs/
+
+# IntelliJ
+.idea


### PR DESCRIPTION
This PR allows specifying a path format via args for the files returned in the zip for `get_subs.py`.

I chose "@" for the format character as it's mostly URL safe (unlike % which can be interpreted as url encoding), and also safe for paths in windows and unix.  Very simple format system that allows flexibility while being safe (unlike `string.format`).